### PR TITLE
Removing 'go' as build dependency so as to not run 'go install go'

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -1,5 +1,5 @@
 export ZOPEN_GIT_URL="https://github.com/muesli/duf.git"
-export ZOPEN_GIT_DEPS="git go comp_go wharf"
+export ZOPEN_GIT_DEPS="git comp_go wharf"
 export ZOPEN_COMP="GO"
 export ZOPEN_TYPE="GIT"
 


### PR DESCRIPTION
zopen build was giving me errors when 'go' was added as a build dependency, because then zopen install would run on it and try to run 'go install go' which was giving me errors