### PR TITLE
Adding termenv build dependency

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -1,8 +1,8 @@
 export ZOPEN_GIT_URL="https://github.com/muesli/duf.git"
-export ZOPEN_GIT_DEPS="git comp_go wharf"
+export ZOPEN_GIT_DEPS="git comp_go wharf termenv"
 export ZOPEN_COMP="GO"
 export ZOPEN_TYPE="GIT"
-
+export GOPATH="$HOME/zopen"
 export ZOPEN_CONFIGURE="zopen_wharf"
 export ZOPEN_CONFIGURE_MINIMAL=1
 export ZOPEN_MAKE="go"


### PR DESCRIPTION
Adding termenv build dependency, though duf still seems to be relying on a buggy import from termenv's repo outside of z/OS